### PR TITLE
Enabling `Prompts Everywhere` to support multiple named `positive inputs` and Chinese translations

### DIFF
--- a/js/use_everywhere_nodes.js
+++ b/js/use_everywhere_nodes.js
@@ -53,7 +53,7 @@ function add_ue_from_node(ues, node) {
             if (in_link) {
                 const type = app.graph._nodes_by_id[node.id.toString()]?.input_type[i];
                 const link = handle_bypass(app.graph.links[in_link], type);
-                if (link) ues.add_ue(node, i, type, [link.origin_id.toString(), link.origin_slot], undefined, new RegExp(["(^prompt|^positive)","neg"][i]), 5);
+                if (link) ues.add_ue(node, i, type, [link.origin_id.toString(), link.origin_slot], undefined, new RegExp(["^(?!.*neg|.*负面)","neg|负面"][i]), 5);
             }
         }
     }

--- a/js/use_everywhere_nodes.js
+++ b/js/use_everywhere_nodes.js
@@ -53,7 +53,7 @@ function add_ue_from_node(ues, node) {
             if (in_link) {
                 const type = app.graph._nodes_by_id[node.id.toString()]?.input_type[i];
                 const link = handle_bypass(app.graph.links[in_link], type);
-                if (link) ues.add_ue(node, i, type, [link.origin_id.toString(), link.origin_slot], undefined, new RegExp(["^(?!.*neg|.*负面)","neg|负面"][i]), 5);
+                if (link) ues.add_ue(node, i, type, [link.origin_id.toString(), link.origin_slot], undefined, new RegExp(["(_|\\b)pos(itive|_|\\b)|^prompt|正面","(_|\\b)neg(ative|_|\\b)|负面"][i]), 5);
             }
         }
     }

--- a/js/use_everywhere_nodes.js
+++ b/js/use_everywhere_nodes.js
@@ -26,7 +26,7 @@ Add UseEverywhere broadcasts from this node to the list
 */
 function add_ue_from_node(ues, node) {
     if (node.type === "Seed Everywhere") ues.add_ue(node, -1, "INT", [node.id.toString(),0], 
-                                                    undefined, new RegExp("seed"), 5);
+                                                    undefined, new RegExp("seed|随机种"), 5);
 
     if (node.type === "Anything Everywhere?") {
         const in_link = node?.inputs[0].link;

--- a/use_everywhere.py
+++ b/use_everywhere.py
@@ -54,7 +54,7 @@ class AnythingEverywherePrompts(Base):
     @classmethod
     def INPUT_TYPES(s):
         return {"required":{}, 
-                "optional": { "^(?!.*neg|.*负面)" : ("*", {}), "neg|负面" : ("*", {}), } }
+                "optional": { "(_|\\b)pos(itive|_|\\b)|^prompt|正面" : ("*", {}), "(_|\\b)neg(ative|_|\\b)|负面" : ("*", {}), } }
     
     def func(self, **kwargs):
         return ()

--- a/use_everywhere.py
+++ b/use_everywhere.py
@@ -54,7 +54,7 @@ class AnythingEverywherePrompts(Base):
     @classmethod
     def INPUT_TYPES(s):
         return {"required":{}, 
-                "optional": { "(^prompt|^positive)" : ("*", {}), "neg" : ("*", {}), } }
+                "optional": { "^(?!.*neg|.*负面)" : ("*", {}), "neg|负面" : ("*", {}), } }
     
     def func(self, **kwargs):
         return ()


### PR DESCRIPTION
Some custom nodes have specially named `positive inputs`, I changed the regular expression of `Prompts Everywhere` to recognize the specially named `positive inputs` and added support for Chinese translation
![2023-12-25 182017](https://github.com/chrisgoringe/cg-use-everywhere/assets/89350747/695d2611-e82d-4052-81a9-5b61ce43a8ba)
![2023-12-25 182035](https://github.com/chrisgoringe/cg-use-everywhere/assets/89350747/30829f75-5401-4119-87ae-759264a5a5a0)
![2023-12-25 182104](https://github.com/chrisgoringe/cg-use-everywhere/assets/89350747/6bbc9106-8e42-4d61-b782-64b3ad08c604)
![2023-12-25 182121](https://github.com/chrisgoringe/cg-use-everywhere/assets/89350747/7f819c4b-a338-455c-ac33-21267c0ee193)
