### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,3 @@ Repository = "https://github.com/chrisgoringe/cg-use-everywhere"
 PublisherId = ""
 DisplayName = "cg-use-everywhere"
 Icon = ""
-Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "cg-use-everywhere"
+description = "Allows Data to be Broadcasted to Some or All Unconnected Inputs."
+version = "1.0.0"
+license = "LICENSE"
+
+[project.urls]
+Repository = "https://github.com/chrisgoringe/cg-use-everywhere"
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "cg-use-everywhere"
+Icon = ""
+Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ]  Go to the [registry](https://comfyregistry.org). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ]  Write a short the description.
- [ ]  Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Please message me on [Discord](https://discord.gg/comfycontrib) if you have any questions!