### PR TITLE
Update slot.label instead of slot.name

### DIFF
--- a/js/use_everywhere_ui.js
+++ b/js/use_everywhere_ui.js
@@ -107,10 +107,10 @@ function displayMessage(id, message) {
 
 function update_input_label(node, slot, app) {
     if (node.input_type[slot]) {
-        node.inputs[slot].name = node.input_type[slot];
+        node.inputs[slot].label = node.input_type[slot];
         node.inputs[slot].color_on = app.canvas.default_connection_color_byType[node.input_type[slot]];
     } else {
-        node.inputs[slot].name = "anything";
+        node.inputs[slot].label = "anything";
         node.inputs[slot].color_on = undefined;
     }
 }


### PR DESCRIPTION
`slot.name` is used as unique identifier so it should not be modified dynamically for display purpose.

This PR changes the ui logic to use `slot.label` instead. This should also fix the issue where the dynamically changed name being overwritten by `localized_name` issue.

Resolves https://github.com/chrisgoringe/cg-use-everywhere/issues/273
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/3360

![image](https://github.com/user-attachments/assets/2490738a-c685-40a8-996a-4cf2dda05f20)
