### PR TITLE
Use node_typing.IO.ANY to replace '*'

### DIFF
--- a/use_everywhere.py
+++ b/use_everywhere.py
@@ -1,5 +1,7 @@
-from server import PromptServer
 import torch
+
+from server import PromptServer
+from comfy.comfy_types.node_typing import IO
 
 def message(id,message):
     if isinstance(message, torch.Tensor):
@@ -42,7 +44,7 @@ class AnythingEverywhere(Base):
     @classmethod
     def INPUT_TYPES(s):
         return {"required":{}, 
-                "optional": { "anything" : ("*", {}), },
+                "optional": { "anything" : (IO.ANY, {}), },
                  "hidden": {"id":"UNIQUE_ID"} }
 
     def func(self, id, **kwargs):
@@ -54,7 +56,7 @@ class AnythingEverywherePrompts(Base):
     @classmethod
     def INPUT_TYPES(s):
         return {"required":{}, 
-                "optional": { "+ve" : ("*", {}), "-ve" : ("*", {}), } }
+                "optional": { "+ve" : (IO.ANY, {}), "-ve" : (IO.ANY, {}), } }
     
     def func(self, **kwargs):
         return ()
@@ -63,7 +65,7 @@ class AnythingEverywhereTriplet(Base):
     @classmethod
     def INPUT_TYPES(s):
         return {"required":{}, 
-                "optional": { "anything" : ("*", {}), "anything2" : ("*", {}), "anything3" : ("*", {}),} }
+                "optional": { "anything" : (IO.ANY, {}), "anything2" : (IO.ANY, {}), "anything3" : (IO.ANY, {}),} }
     
     def func(self, **kwargs):
         return ()
@@ -73,7 +75,7 @@ class AnythingSomewhere(Base):
     def INPUT_TYPES(s):
         return {"required":{}, 
                 "optional": { 
-                    "anything" : ("*", {}), 
+                    "anything" : (IO.ANY, {}), 
                     "title_regex" : ("STRING", {"default":".*"}),
                     "input_regex" : ("STRING", {"default":".*"}),
                     "group_regex" : ("STRING", {"default":".*"}),


### PR DESCRIPTION
Resolves https://github.com/chrisgoringe/cg-use-everywhere/issues/276
Ref: https://github.com/comfyanonymous/ComfyUI/blob/98bdca4cb2907ad10bd24776c0b7587becdd5734/comfy/comfy_types/node_typing.py#L52

Before patch:
```
got prompt
Failed to validate prompt for output 10:
* (prompt):
  - Return type mismatch between linked nodes: anything, received_type(MODEL) mismatch input_type(*)
* Anything Everywhere3 10:
  - Return type mismatch between linked nodes: anything, received_type(MODEL) mismatch input_type(*)
Output will be ignored
```

After patch:
No error in console

Workflow used for testing:
[everywhere.json](https://github.com/user-attachments/files/19686591/everywhere.json)
